### PR TITLE
Add Ctrl/Cmd+Click to edit the timediff code block

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -113,6 +113,22 @@ export default class TimeDiffPlugin extends Plugin {
 		this.registerMarkdownCodeBlockProcessor(
 			"timediff",
 			(source, el, _ctx) => {
+				el.addEventListener("click", (ev) => {
+					if (ev.ctrlKey || ev.metaKey) {
+						const view =
+							this.app.workspace.getActiveViewOfType(
+								MarkdownView
+							);
+						if (view) {
+							const sectionInfo = _ctx.getSectionInfo(el);
+							if (sectionInfo) {
+								ev.preventDefault();
+								view.editor.setCursor(sectionInfo.lineStart, 0);
+								view.editor.focus();
+							}
+						}
+					}
+				});
 				let totalSumInMinutes = 0;
 				const rows = source.split("\n").filter((row) => row.length > 0);
 				for (const row of rows) {


### PR DESCRIPTION
This PR adds a click listener to the timediff code block processor that jumps to the code block in the editor when Ctrl/Cmd+Click is used. This makes it easier to edit the specific code block from the preview/reading mode. This reduces mouse movement specially the time block becomes large and I was missing the clicks on the edit icon. 